### PR TITLE
Update OSV-Scanner workflow configuration

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,6 +26,8 @@ permissions:
   security-events: write
   # Read commit contents
   contents: read
+  # Required by osv-scanner-action
+  actions: read
 
 jobs:
   scan-scheduled:


### PR DESCRIPTION
## Description
Fixes the OSV-Scanner workflow validation error by adding the required `actions: read` permission.

## Problem
The workflow was failing with:

```bash
Check failure on line 31 in .github/workflows/osv-scanner.yml


GitHub Actions
/ OSV-Scanner
Invalid workflow file

The workflow is not valid. .github/workflows/osv-scanner.yml (Line: 31, Col: 3): Error calling workflow 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.5'. The workflow is requesting 'actions: read', but is only allowed 'actions: none'.
```

## Solution
Added `actions: read` to the `permissions` block in `.github/workflows/osv-scanner.yml` to satisfy the requirements of the reusable workflow from google/osv-scanner-action.

## Changes
- Added `actions: read` permission to osv-scanner workflow

## Type of Change
- [x] Bug fix
- [ ] New feature

## Testing
The workflow should now validate successfully when triggered on pull requests, merges, pushes, and scheduled runs.